### PR TITLE
Generate fresh Sudoku puzzle on startup

### DIFF
--- a/src/gui/SudokuSolver.java
+++ b/src/gui/SudokuSolver.java
@@ -137,6 +137,7 @@ public class SudokuSolver extends JFrame {
 		inputBoard = new Board();
 		gbc.gridy++;
 		this.add(inputBoard, gbc);
+		inputBoard.alter(Generator.generateInstance());
 		
 		outputBoard = new Board();
 		gbc.gridx++;


### PR DESCRIPTION
Previously both boards were empty on startup. Now the sudoku instance
will contain a puzzle.

Closes #4 